### PR TITLE
fixing center authLayout.tsx responsively

### DIFF
--- a/src/layouts/auth/authLayout.tsx
+++ b/src/layouts/auth/authLayout.tsx
@@ -58,7 +58,9 @@ const AuthLayout: FC<TLayout> = ({
           </a>
         </Box>
       </Box>
-      <Box w={["100%", "100%", "50%"]} mx={"2em"} py={"1rem"}>
+      <Box w={["100%", "100%", "50%"]} display={"flex"}
+        alignItems={"center"}
+        justifyContent={"center"} px={"2em"} py={"1rem"}>
         <Box width={["100%", "100%", "550px"]} mx={"auto"} py={"2rem"}>
           <Text fontWeight={"bold"} fontSize={["20px", "20px", "25px"]}>
             {layoutHeader}


### PR DESCRIPTION
So I fix the layout so that the signup and signin Box are centered, I remove the margin left that was causing an overflow outside the window on smartphone width and also let the height be natural so that the whole form can be scrolled and visible in smartphone
Please check and let me know 